### PR TITLE
fix(pkg/checker) Adding Bearer Token header for API Server requests

### DIFF
--- a/pkg/checker/transport.go
+++ b/pkg/checker/transport.go
@@ -23,7 +23,7 @@ func (c *Checker) doRequest(url string) (string, error) {
 	client := c.HTTPClient
 	req, err := http.NewRequest("GET", url, nil)
 	// Only add the Bearer for API Server Requests
-	if strings.Contains(url, "/version") && token != nil {
+	if strings.HasSuffix(url, "/version") && token != nil {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 

--- a/pkg/checker/transport.go
+++ b/pkg/checker/transport.go
@@ -2,12 +2,32 @@ package checker
 
 import (
 	"errors"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"strings"
+)
+
+const (
+	tokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 // doRequest does an http request only to get the http status code
 func (c *Checker) doRequest(url string) (string, error) {
-	resp, err := c.HTTPClient.Get(url)
+	// Read Bearer Token file from ServiceAccount
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		fmt.Errorf("could not load token %s: %s", tokenFile, err)
+	}
+
+	client := c.HTTPClient
+	req, err := http.NewRequest("GET", url, nil)
+	// Only add the Bearer for API Server Requests
+	if strings.Contains(url, "/version") && token != nil {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return err.Error(), err
 	}

--- a/pkg/checker/transport.go
+++ b/pkg/checker/transport.go
@@ -17,13 +17,13 @@ func (c *Checker) doRequest(url string) (string, error) {
 	// Read Bearer Token file from ServiceAccount
 	token, err := ioutil.ReadFile(tokenFile)
 	if err != nil {
-		fmt.Errorf("could not load token %s: %s", tokenFile, err)
+		return "error", fmt.Errorf("could not load token %s: %s", tokenFile, err)
 	}
 
 	client := c.HTTPClient
 	req, err := http.NewRequest("GET", url, nil)
 	// Only add the Bearer for API Server Requests
-	if strings.HasSuffix(url, "/version") && token != nil {
+	if strings.HasSuffix(url, "/version") {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 


### PR DESCRIPTION
Hey guys. 

I got a `401 Unauthorized` when tried to use kubenurse on our cluster. Looking deeper I found that appearly the transport code doesn't use the `token` provided by the ServiceAccount `nurse` with the ClusterRole `view`. 

I've only found a code block adding the CA Cert (and this isn't enough) and I've also found a code at `kubediscovery` pkg with a client from `client-go` of kubernetes. At first I started changing the code to use this client but I ending in a "keep it simple" way and only added the token for requests with `/version` in the URI.

I'm using this fork on our cluster and now everything is working good. I'm open to change the way of the fix if you guys are thinking in a different approach to solve the problem.