### PR TITLE
Add optional Prometheus operator ServiceMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | ---------------------------------|---------------------------------------------------------------------------------------------------- | --------------------- |
 | daemonset.image.repository       | The repository name                                                                                 | postfinance/kubenurse |
 | daemonset.image.tag              | The tag/ version of the image                                                                       | v1.4.0                |
+| daemonset.podLabels              | Additional Labels to be added to the pods of the ademonset | []
+| daemonset.podAnnotations         | Additional Annotations to be added to the pods of the daemonset | []
 | daemonset.securityContext        | The security context of the daemonset | {}
 | daemonset.containerSecurityContext| The Security context of the containers within the pods of the daemonset | {}
 | namespace                        | The namespace where kubenurse will be deployed                                                      | kube-system           |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | daemonset.podAnnotations         | Additional Annotations to be added to the pods of the daemonset | []
 | daemonset.securityContext        | The security context of the daemonset | {}
 | daemonset.containerSecurityContext| The Security context of the containers within the pods of the daemonset | {}
+| daemonset.tolerations | The Tolerations of the daemonset |   <code>- effect: NoSchedule </br>&nbsp; key: node-role.kubernetes.io/master</br>&nbsp; operator: Equal </br>- effect: NoSchedule </br>&nbsp; key: node-role.kubernetes.io/control-plane</br>&nbsp; operator: Equal</code>
 | namespace                        | The namespace where kubenurse will be deployed                                                      | kube-system           |
 | serviceMonitor.enabled | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | false
 | serviceMonitor.labels | Additional Labels to be added to the ServiceMonitor | {}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | daemonset.image.repository       | The repository name                                                                                 | postfinance/kubenurse |
 | daemonset.image.tag              | The tag/ version of the image                                                                       | v1.4.0                |
 | namespace                        | The namespace where kubenurse will be deployed                                                      | kube-system           |
+| serviceMonitor.enabled | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | false
+| serviceMonitor.labels | Additional Labels to be added to the ServiceMonitor | {}
 | serviceAccount.name              | The name of the service account which is used                                                       | kubenurse             |
 | service.name                     | The name of service which exposes the kubenurse application                                         | 8080-8080             |
 | service.port                     | The port number of the service                                                                      | 8080                  |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | serviceAccount.name              | The name of the service account which is used                                                       | kubenurse             |
 | service.name                     | The name of service which exposes the kubenurse application                                         | 8080-8080             |
 | service.port                     | The port number of the service                                                                      | 8080                  |
+| service.labels | Additional labels to be added to the Service | 
 | ingress.enabled                  | Enable/ Disable the ingress                                                                         | true                  |
 | ingress.className                | The classname of the ingress controller (e.g. the nginx ingress controller)                         | nginx                 |
 | ingress.url                      | The url of the ingress; e.g. kubenurse.westeurope.cloudapp.azure.com                                | dummy.kubenurse.com   |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | ---------------------------------|---------------------------------------------------------------------------------------------------- | --------------------- |
 | daemonset.image.repository       | The repository name                                                                                 | postfinance/kubenurse |
 | daemonset.image.tag              | The tag/ version of the image                                                                       | v1.4.0                |
+| daemonset.securityContext        | The security context of the daemonset | {}
+| daemonset.containerSecurityContext| The Security context of the containers within the pods of the daemonset | {}
 | namespace                        | The namespace where kubenurse will be deployed                                                      | kube-system           |
 | serviceMonitor.enabled | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | false
 | serviceMonitor.labels | Additional Labels to be added to the ServiceMonitor | {}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | daemonset.image.tag              | The tag/ version of the image                                                                       | v1.4.0                |
 | daemonset.podLabels              | Additional Labels to be added to the pods of the ademonset | []
 | daemonset.podAnnotations         | Additional Annotations to be added to the pods of the daemonset | []
-| daemonset.securityContext        | The security context of the daemonset | {}
+| daemonset.podSecurityContext        | The security context of the daemonset | {}
 | daemonset.containerSecurityContext| The Security context of the containers within the pods of the daemonset | {}
 | daemonset.tolerations | The Tolerations of the daemonset |   <code>- effect: NoSchedule </br>&nbsp; key: node-role.kubernetes.io/master</br>&nbsp; operator: Equal </br>- effect: NoSchedule </br>&nbsp; key: node-role.kubernetes.io/control-plane</br>&nbsp; operator: Equal</code>
 | namespace                        | The namespace where kubenurse will be deployed                                                      | kube-system           |

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -69,9 +69,6 @@ spec:
           successThreshold: 1
           timeoutSeconds: 1
       tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-        operator: Equal
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/control-plane
-        operator: Equal
+      {{- if .Values.daemonset.tolerations }}
+      {{- toYaml .Values.daemonset.tolerations | nindent 6 }}
+      {{- end }}

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -22,9 +22,17 @@ spec:
         prometheus.io/scheme: "http"
         prometheus.io/scrape: "true"
     spec:
+      securityContext:
+      {{- if .Values.daemonset.podSecurityContext -}}
+      {{ toYaml .Values.daemonset.podSecurityContext | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "name" . | quote }}
       containers:
       - name: {{ include "name" . | quote }}
+        securityContext:
+          {{- if .Values.daemonset.containerSecurityContext -}}
+          {{ toYaml .Values.daemonset.containerSecurityContext | nindent 10 }}
+          {{- end }}
         env:
         - name: KUBENURSE_INGRESS_URL
           value: https://{{ .Values.ingress.url }}

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -14,6 +14,9 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.daemonset.podLabels }}
+        {{- toYaml .Values.daemonset.podLabels | nindent 8 }}
+        {{- end }}
         app: {{ include "name" . | quote }}
 {{ include "common-labels" . | indent 8 }}
       annotations:
@@ -21,6 +24,9 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/scheme: "http"
         prometheus.io/scrape: "true"
+        {{- if .Values.daemonset.podAnnotations }}
+        {{- toYaml .Values.daemonset.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       securityContext:
       {{- if .Values.daemonset.podSecurityContext -}}

--- a/helm/kubenurse/templates/service.yaml
+++ b/helm/kubenurse/templates/service.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    {{- if .Values.service.labels }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- end }}
     app: {{ include "name" . | quote }}
 {{ include "common-labels" . | indent 4 }}
   name: {{ include "name" . | quote }}

--- a/helm/kubenurse/templates/servicemonitor.yaml
+++ b/helm/kubenurse/templates/servicemonitor.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: kubenurse-metrics
+  name: {{ include "name" . | quote }}
   namespace: {{ .Values.namespace }}
   labels:
     {{- toYaml .Values.serviceMonitor.labels | nindent 4}}

--- a/helm/kubenurse/templates/servicemonitor.yaml
+++ b/helm/kubenurse/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: kubenurse-metrics
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
+spec:
+  endpoints:
+  - port: {{ .Values.service.name }}
+    interval: 60s
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.namespace }}
+  selector:
+    matchLabels:
+{{ include "common-labels" . | indent 6 }}
+{{- end -}}

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -3,6 +3,8 @@ daemonset:
     repository: postfinance/kubenurse
     tag: v1.5.1
   extraEnvs: []
+  podSecurityContext: {}
+  containerSecurityContext: {}
 
 serviceMonitor: 
   enabled: false

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -3,6 +3,8 @@ daemonset:
     repository: postfinance/kubenurse
     tag: v1.5.1
   extraEnvs: []
+  podLabels: {}
+  podAnnotations: {}
   podSecurityContext: {}
   containerSecurityContext: {}
 

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -4,6 +4,10 @@ daemonset:
     tag: v1.5.1
   extraEnvs: []
 
+serviceMonitor: 
+  enabled: false
+  labels: {}
+
 namespace: kube-system
 
 serviceAccount:

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -7,6 +7,13 @@ daemonset:
   podAnnotations: {}
   podSecurityContext: {}
   containerSecurityContext: {}
+  tolerations: 
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Equal
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Equal
 
 serviceMonitor: 
   enabled: false

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -20,6 +20,7 @@ serviceAccount:
 service:
   name: 8080-8080
   port: 8080
+  labels: {}
 
 ingress:
   enabled: true


### PR DESCRIPTION
To increase the flexibility of the helm chart, this pull request adds several additional configuration options:

- support for an optional [ServiceMonitor](https://github.com/SamhammerAG/kubenurse.git).
- additional pod labels/annotations.
- pod and container securityContexts.
- additional labels on the service.
- custom tolerations (or to remove the default tolerations).use release name insteaduse release name instead