### PR TITLE
fix(helm): parse error when using extraEnvs

### DIFF
--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -52,8 +52,8 @@ spec:
           value: {{ .Values.namespace }}
         - name: KUBENURSE_NEIGHBOUR_FILTER
           value: app={{ include "name" . }}
-          {{- if .Values.daemonset.extraEnvs }}
-            {{- toYaml .Values.daemonset.extraEnvs | indent 12 }}
+          {{- if .Values.daemonset.extraEnvs -}}
+          {{- toYaml .Values.daemonset.extraEnvs | nindent 8 }}
           {{- end }}
         image: {{ include "image" . | quote }}
         ports:


### PR DESCRIPTION
This should fix the following error when using envVars:

```
Error: YAML parse error on kubenurse/templates/daemonset.yaml: error converting YAML to JSON: yaml: line 42: mapping values are not allowed in this context

Use --debug flag to render out invalid YAML
```