### PR TITLE
fix(helm): chart should respect `-n <namespace>` flag

### DIFF
--- a/helm/kubenurse/templates/_helpers.tpl
+++ b/helm/kubenurse/templates/_helpers.tpl
@@ -16,3 +16,7 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
 {{ define "image" -}}
 {{ printf "%s:%s" .Values.daemonset.image.repository .Values.daemonset.image.tag }}
 {{- end }}
+
+{{- define "namespace" -}}
+{{- default .Release.Namespace .Values.namespace | quote -}}
+{{- end -}}

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ include "name" . | quote }}
 {{ include "helm-labels" . | indent 4 }}
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 spec:
   selector:
     matchLabels:

--- a/helm/kubenurse/templates/ingress.yaml
+++ b/helm/kubenurse/templates/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 spec:
   tls:
   - hosts:

--- a/helm/kubenurse/templates/rbac.yaml
+++ b/helm/kubenurse/templates/rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -11,13 +11,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 rules:
 - apiGroups:
   - ""
@@ -40,7 +40,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/kubenurse/templates/service.yaml
+++ b/helm/kubenurse/templates/service.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ include "name" . | quote }}
 {{ include "common-labels" . | indent 4 }}
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
 spec:
   ports:
   - name: {{ .Values.service.name }}

--- a/helm/kubenurse/templates/serviceaccount.yaml
+++ b/helm/kubenurse/templates/serviceaccount.yaml
@@ -5,4 +5,4 @@ metadata:
   name: {{ .Values.serviceAccount.name }}
   labels:
 {{ include "common-labels" . | indent 6 }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}

--- a/helm/kubenurse/templates/servicemonitor.yaml
+++ b/helm/kubenurse/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "name" . | quote }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ include "namespace" . }}
   labels:
     {{- toYaml .Values.serviceMonitor.labels | nindent 4}}
 spec:


### PR DESCRIPTION
Namespace should be configured via `-n` helm flag.

I kept the `namespace` value in `values.yaml` for backward compatibility reasons. But it would probably be better to set as

```yaml
namespace: ""
```

Then, per default, the `Releases.Namespace` value is taken and you still can overwrite it in `values.yaml`.

Currently, if someone wants to install the helm chart, it gets installed in `kube-system` namespace. Even if you specify `-n other-namespace` . You have to actively set `namespace: ""` in `values.yaml` to make it installable in a different namespace via helm flags.

@djboris9 let me know what you think.

**Edit**:

Best practices is discussed [here](https://github.com/helm/helm/issues/5465). I get the feeling that `namespace: {{ .Releases.Namespace }}` would be best.