### PR TITLE
introduce feature flags to control checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ kubenurse is configured with environment variables:
 - `KUBENURSE_NAMESPACE`: Namespace in which to look for the neighbour kubenurses
 - `KUBENURSE_NEIGHBOUR_FILTER`: A Kubernetes label selector (eg. `app=kubenurse`) to filter neighbour kubenurses
 - `KUBENURSE_ALLOW_UNSCHEDULABLE`: If this is `"true"`, path checks to neighbouring kubenurses are made even if they are running on unschedulable nodes.
+- `KUBENURSE_CHECK_API_SERVER_DIRECT`: If this is `"true"` kubenurse will perform the check [API Server Direct](###API Server Direct). default is "true"
+- `KUBENURSE_CHECK_API_SERVER_DNS`: If this is `"true"`, kubenurse will perform the check [API Server DNS](###API Server DNS). default is "true"
+- `KUBENURSE_CHECK_ME_INGRESS`: If this is `"true"`, kubenurse will perform the check [Me Ingress](###Me Ingress). default is "true"
+- `KUBENURSE_CHECK_ME_SERVICE`: If this is `"true"`, kubenurse will perform the check [Me Service](###Me Service). default is "true"
+- `KUBENURSE_CHECK_NEIGHBOURHOOD`: If this is `"true"`, kubenurse will perform the check [Neighbourhood](###Neighbourhood). default is "true"
 - `KUBENURSE_USE_TLS`: If this is `"true"`, enable TLS endpoint on port 8443
 - `KUBENURSE_CERT_FILE`: Certificate to use with TLS endpoint
 - `KUBENURSE_CERT_KEY`: Key to use with TLS endpoint

--- a/examples/ingress.yaml
+++ b/examples/ingress.yaml
@@ -1,3 +1,4 @@
+# This resource is not needed if KUBENURSE_CHECK_ME_INGRESS=false
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/examples/service.yaml
+++ b/examples/service.yaml
@@ -1,4 +1,5 @@
 ---
+# This resource is not needed if KUBENURSE_CHECK_ME_SERVICE=false
 apiVersion: v1
 kind: Service
 metadata:

--- a/internal/kubenurse/server.go
+++ b/internal/kubenurse/server.go
@@ -43,6 +43,11 @@ type Server struct {
 // * KUBERNETES_SERVICE_PORT
 // * KUBENURSE_NAMESPACE
 // * KUBENURSE_NEIGHBOUR_FILTER
+// * KUBENURSE_CHECK_API_SERVER_DIRECT
+// * KUBENURSE_CHECK_API_SERVER_DNS
+// * KUBENURSE_CHECK_ME_INGRESS
+// * KUBENURSE_CHECK_ME_SERVICE
+// * KUBENURSE_CHECK_NEIGHBOURHOOD
 func New(ctx context.Context, k8s kubernetes.Interface) (*Server, error) {
 	mux := http.NewServeMux()
 
@@ -93,6 +98,14 @@ func New(ctx context.Context, k8s kubernetes.Interface) (*Server, error) {
 	chk.KubernetesServicePort = os.Getenv("KUBERNETES_SERVICE_PORT")
 	chk.KubenurseNamespace = os.Getenv("KUBENURSE_NAMESPACE")
 	chk.NeighbourFilter = os.Getenv("KUBENURSE_NEIGHBOUR_FILTER")
+
+	//nolint:goconst // No need to make "false" a constant in my opinion, readability is better like this.
+	chk.SkipCheckAPIServerDirect = os.Getenv("KUBENURSE_CHECK_API_SERVER_DIRECT") == "false"
+	chk.SkipCheckAPIServerDNS = os.Getenv("KUBENURSE_CHECK_API_SERVER_DNS") == "false"
+	chk.SkipCheckMeIngress = os.Getenv("KUBENURSE_CHECK_ME_INGRESS") == "false"
+	chk.SkipCheckMeService = os.Getenv("KUBENURSE_CHECK_ME_SERVICE") == "false"
+	chk.SkipCheckNeighbourhood = os.Getenv("KUBENURSE_CHECK_NEIGHBOURHOOD") == "false"
+
 	chk.UseTLS = server.useTLS
 
 	server.checker = chk

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -16,6 +16,7 @@ import (
 const (
 	okStr            = "ok"
 	errStr           = "error"
+	skippedStr       = "skipped"
 	metricsNamespace = "kubenurse"
 )
 
@@ -98,17 +99,21 @@ func (c *Checker) Run() (Result, bool) {
 	res.MeService, err = c.measure(c.MeService, "me_service")
 	haserr = haserr || (err != nil)
 
-	res.Neighbourhood, err = c.discovery.GetNeighbours(context.TODO(), c.KubenurseNamespace, c.NeighbourFilter)
-	haserr = haserr || (err != nil)
-
-	// Neighbourhood special error treating
-	if err != nil {
-		res.NeighbourhoodState = err.Error()
+	if c.SkipCheckNeighbourhood {
+		res.NeighbourhoodState = skippedStr
 	} else {
-		res.NeighbourhoodState = okStr
+		res.Neighbourhood, err = c.discovery.GetNeighbours(context.TODO(), c.KubenurseNamespace, c.NeighbourFilter)
+		haserr = haserr || (err != nil)
 
-		// Check all neighbours if the neighbourhood was discovered
-		c.checkNeighbours(res.Neighbourhood)
+		// Neighbourhood special error treating
+		if err != nil {
+			res.NeighbourhoodState = err.Error()
+		} else {
+			res.NeighbourhoodState = okStr
+
+			// Check all neighbours if the neighbourhood was discovered
+			c.checkNeighbours(res.Neighbourhood)
+		}
 	}
 
 	// Cache result
@@ -140,23 +145,35 @@ func (c *Checker) StopScheduled() {
 
 // APIServerDirect checks the /version endpoint of the Kubernetes API Server through the direct link
 func (c *Checker) APIServerDirect() (string, error) {
+	if c.SkipCheckAPIServerDirect {
+		return skippedStr, nil
+	}
 	apiurl := fmt.Sprintf("https://%s:%s/version", c.KubernetesServiceHost, c.KubernetesServicePort)
 	return c.doRequest(apiurl)
 }
 
 // APIServerDNS checks the /version endpoint of the Kubernetes API Server through the Cluster DNS URL
 func (c *Checker) APIServerDNS() (string, error) {
+	if c.SkipCheckAPIServerDNS {
+		return skippedStr, nil
+	}
 	apiurl := fmt.Sprintf("https://kubernetes.default.svc.cluster.local:%s/version", c.KubernetesServicePort)
 	return c.doRequest(apiurl)
 }
 
 // MeIngress checks if the kubenurse is reachable at the /alwayshappy endpoint behind the ingress
 func (c *Checker) MeIngress() (string, error) {
+	if c.SkipCheckMeIngress {
+		return skippedStr, nil
+	}
 	return c.doRequest(c.KubenurseIngressURL + "/alwayshappy")
 }
 
 // MeService checks if the kubenurse is reachable at the /alwayshappy endpoint through the kubernetes service
 func (c *Checker) MeService() (string, error) {
+	if c.SkipCheckMeService {
+		return skippedStr, nil
+	}
 	return c.doRequest(c.KubenurseServiceURL + "/alwayshappy")
 }
 

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -148,6 +148,7 @@ func (c *Checker) APIServerDirect() (string, error) {
 	if c.SkipCheckAPIServerDirect {
 		return skippedStr, nil
 	}
+
 	apiurl := fmt.Sprintf("https://%s:%s/version", c.KubernetesServiceHost, c.KubernetesServicePort)
 	return c.doRequest(apiurl)
 }
@@ -157,6 +158,7 @@ func (c *Checker) APIServerDNS() (string, error) {
 	if c.SkipCheckAPIServerDNS {
 		return skippedStr, nil
 	}
+
 	apiurl := fmt.Sprintf("https://kubernetes.default.svc.cluster.local:%s/version", c.KubernetesServicePort)
 	return c.doRequest(apiurl)
 }
@@ -166,6 +168,7 @@ func (c *Checker) MeIngress() (string, error) {
 	if c.SkipCheckMeIngress {
 		return skippedStr, nil
 	}
+
 	return c.doRequest(c.KubenurseIngressURL + "/alwayshappy")
 }
 
@@ -174,6 +177,7 @@ func (c *Checker) MeService() (string, error) {
 	if c.SkipCheckMeService {
 		return skippedStr, nil
 	}
+
 	return c.doRequest(c.KubenurseServiceURL + "/alwayshappy")
 }
 

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -150,6 +150,7 @@ func (c *Checker) APIServerDirect() (string, error) {
 	}
 
 	apiurl := fmt.Sprintf("https://%s:%s/version", c.KubernetesServiceHost, c.KubernetesServicePort)
+
 	return c.doRequest(apiurl)
 }
 
@@ -160,6 +161,7 @@ func (c *Checker) APIServerDNS() (string, error) {
 	}
 
 	apiurl := fmt.Sprintf("https://kubernetes.default.svc.cluster.local:%s/version", c.KubernetesServicePort)
+
 	return c.doRequest(apiurl)
 }
 

--- a/internal/servicecheck/types.go
+++ b/internal/servicecheck/types.go
@@ -13,15 +13,20 @@ type Checker struct {
 	// Ingress and service config
 	KubenurseIngressURL string
 	KubenurseServiceURL string
+	SkipCheckMeIngress  bool
+	SkipCheckMeService  bool
 
 	// Kubernetes API
-	KubernetesServiceHost string
-	KubernetesServicePort string
+	KubernetesServiceHost    string
+	KubernetesServicePort    string
+	SkipCheckAPIServerDirect bool
+	SkipCheckAPIServerDNS    bool
 
 	// Neighbourhood
-	KubenurseNamespace string
-	NeighbourFilter    string
-	allowUnschedulable bool
+	KubenurseNamespace     string
+	NeighbourFilter        string
+	allowUnschedulable     bool
+	SkipCheckNeighbourhood bool
 
 	// TLS
 	UseTLS bool


### PR DESCRIPTION
Running kubenurse at scale (~ 1000 node) can have a negative performance impact on the Kubernetes control plane
for example, creating a service for the kubenurse daemonset requires CNI Providers (flannel in my case) to track ALL pods in the iptable rules of all nodes, which will be huge and may lead to increased memory consumption on flannel

Also, neighborhood checks can overload the Kubernetes API server for discovery information.

In addition, I have tools to monitor some stuff that kubenurse covers and I wanted to use only what I need from kubenurse

This PR creates control to disable some of the checks when needed, but does not change the behavior as all checks are enabled by default
