### PR TITLE
migrate to histogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ All performed checks expose metrics which can be used to monitor/alert:
 
 At `/metrics` you will find these:
 - `kubenurse_errors_total`: Kubenurse error counter partitioned by error type
-- `kubenurse_request_duration`: Kubenurse request duration partitioned by error type, summary over one minute
+- `kubenurse_request_duration`: a histogram for Kubenurse request duration partitioned by error type

--- a/doc/grafana-kubenurse.json
+++ b/doc/grafana-kubenurse.json
@@ -66,7 +66,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "kubenurse_request_duration{quantile=\"0.9\", type=~\"$type\"}",
+          "expr": "histogram_quantile(0.9, rate(kubenurse_request_duration{type=~\"$type\"}[1m]))",
           "interval": "",
           "legendFormat": "{{pod}}: {{type}}",
           "refId": "A"

--- a/internal/servicecheck/types.go
+++ b/internal/servicecheck/types.go
@@ -34,8 +34,8 @@ type Checker struct {
 	discovery *kubediscovery.Client
 
 	// metrics
-	errorCounter    *prometheus.CounterVec
-	durationSummary *prometheus.SummaryVec
+	errorCounter      *prometheus.CounterVec
+	durationHistogram *prometheus.HistogramVec
 
 	// Http Client for https requests
 	httpClient *http.Client


### PR DESCRIPTION
Motivation for changing `prometheus.SummaryVec` to `prometheus.HistogramVec`:
1. `prometheus.HistogramVec` can be aggregated, which allows knowing the latency calling a specific node as observed by every other node in the cluster `histogram_quantile(0.9, sum by (type, le) (rate(kubenurse_request_duration_bucket{type=~"path_ip-.*"}[5m])))` while this is [not possible](https://latencytipoftheday.blogspot.com/2014/06/latencytipoftheday-you-cant-average.html) with `prometheus.SummaryVec`
2. histogram calculates quantile on the server side, which has 2 positive effects in large clusters. 
    1.  you can form 0.9 or higher quantile with a lower number of observations per pod `KUBENURSE_CHECK_INTERVAL`, since the observations made by all nodes can be aggregated together
    2. cheaper observations made by the clients as they do not need to calculate quantiles

[ for more details](https://prometheus.io/docs/practices/histograms/)