### PR TITLE
added priorityClassName support for helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | daemonset.podLabels                | Additional labels to be added to the pods of the daemonset                                                           | `[]`                               |
 | daemonset.podAnnotations           | Additional annotations to be added to the pods of the daemonset                                                      | `[]`                               |
 | daemonset.podSecurityContext       | The security context of the daemonset                                                                                | `{}`                               |
+| daemonset.priorityClassName        | The priority class name for the daemonset pods                                                                       | `""`                               |
 | daemonset.containerSecurityContext | The security context of the containers within the pods of the daemonset                                              | `{}`                               |
 | daemonset.containerResources       | The container resources of the containers within the pods of the daemonset                                           | `{}`                               |
 | daemonset.containerImagePullPolicy | The container image pull policy the pods of the daemonset                                                            | `IfNotPresent`                     |

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -128,3 +128,6 @@ spec:
       {{- if .Values.daemonset.volumes -}}
       {{- toYaml .Values.daemonset.volumes | nindent 6 }}
       {{- end }}
+      {{- if .Values.daemonset.priorityClassName }}
+      priorityClassName: {{ .Values.daemonset.priorityClassName }}
+      {{- end }}

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -19,6 +19,7 @@ daemonset:
   dnsConfig: {}
   volumeMounts: []
   volumes: []
+  priorityClassName: ""
 
 serviceMonitor: 
   enabled: false


### PR DESCRIPTION
added support for kubernetes [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)

Value is optional and default is ""
If value is not set or empty then priorityClassName will be ignored in deamonset