### PR TITLE
fix: added missing condition in ingress.yaml chart file

### DIFF
--- a/helm/kubenurse/templates/ingress.yaml
+++ b/helm/kubenurse/templates/ingress.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -22,3 +23,4 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.url }}
+{{- end -}}


### PR DESCRIPTION
Correction of a bug in the Helm chart regarding the activation of Ingress deployment from the Helm chart.

Indeed, the condition `ingress.enabled: true` does exist in the `values.yaml` file but is never applied to the ingress.yaml file.