### PR TITLE
add annotation and TLS secretName to ingress

### DIFF
--- a/helm/kubenurse/templates/ingress.yaml
+++ b/helm/kubenurse/templates/ingress.yaml
@@ -5,6 +5,10 @@ kind: Ingress
 metadata:
   labels:
     {{- include "kubenurse.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "kubenurse.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
@@ -23,4 +27,5 @@ spec:
   tls:
   - hosts:
     - {{ .Values.ingress.url }}
+    secretName: kubenurse-ingress-tls
 {{- end -}}

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -85,5 +85,6 @@ service:
 ingress:
   enabled: true
   className: nginx
+  annotations: {}
   # KUBENURSE_INGRESS_URL
   url: dummy-kubenurse.example.com


### PR DESCRIPTION
Add annotation and secretName to ingress template.
Now ingress can used with Cert-manager. For example to generate HTTPS let'sencrypt certificate.

```
$ helm template kubenurse helm/kubenurse/ --show-only templates/ingress.yaml --set 'ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt-http01'
---
# Source: kubenurse/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  labels:
    helm.sh/chart: kubenurse-0.0.1-dummy
    app.kubernetes.io/name: kubenurse
    app.kubernetes.io/instance: kubenurse
    app.kubernetes.io/version: "v0.0.1-dummy"
    app.kubernetes.io/managed-by: Helm
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-http01
  name: kubenurse
  namespace: default
spec:
  ingressClassName: nginx
  rules:
  - host: dummy-kubenurse.example.com
    http:
      paths:
      - backend:
          service:
            name: kubenurse
            port:
              number: 8080
        path: /
        pathType: Prefix
  tls:
  - hosts:
    - dummy-kubenurse.example.com
    secretName: kubenurse-ingress-tls
```