### PR TITLE
feat: support setting .endpoints[].relabelings in ServiceMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | daemonset.volumes                  | Additional volumes to be added to the daemonset                                                                      | `[]`                               |
 | serviceMonitor.enabled             | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | `false`                            |
 | serviceMonitor.labels              | Additional labels to be added to the ServiceMonitor                                                                  | `{}`                               |
+| serviceMonitor.relabelings         | Additional relabelings to be added to the endpoint of the ServiceMonitor                                             | `[]`                               |
 | serviceAccount.name                | The name of the service account which is used                                                                        | `Release.Name`                     |
 | service.name                       | The name of service which exposes the kubenurse application                                                          | `8080-8080`                        |
 | service.port                       | The port number of the service                                                                                       | `8080`                             |

--- a/helm/kubenurse/templates/servicemonitor.yaml
+++ b/helm/kubenurse/templates/servicemonitor.yaml
@@ -13,6 +13,10 @@ spec:
   endpoints:
   - port: {{ .Values.service.name }}
     interval: 60s
+    {{- with .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml . | nindent 6 }}
+    {{- end }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -26,6 +26,13 @@ daemonset:
 serviceMonitor:
   enabled: false
   labels: {}
+  relabelings: []
+  # - sourceLabels: [__meta_kubernetes_pod_node_name]
+  #   separator: ;
+  #   regex: ^(.*)$
+  #   targetLabel: nodename
+  #   replacement: $1
+  #   action: replace
 
 # environment variables
 #


### PR DESCRIPTION
Hi 👋,

I would like introduces an enhancement to the Helm chart by allowing users to configure the `spec.endpoints[].relabelings` field in the ServiceMonitor. This will enable the export of additional metrics (e.g. the Node name of the Pod) without requiring manual modifications to the chart.