### PR TITLE
fix: don't set spec.updateStrategy.maxSurge of DaemonSet by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,49 +94,51 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 <details>
 <summary>helm parameters list</summary>
 
-| Setting                            | Description                                                                                                          | Default                            |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| daemonset.image.repository         | The repository name                                                                                                  | `postfinance/kubenurse`            |
-| daemonset.image.tag                | The tag/ version of the image                                                                                        | `v1.4.0`                           |
-| daemonset.podLabels                | Additional labels to be added to the pods of the daemonset                                                           | `[]`                               |
-| daemonset.podAnnotations           | Additional annotations to be added to the pods of the daemonset                                                      | `[]`                               |
-| daemonset.podSecurityContext       | The security context of the daemonset                                                                                | `{}`                               |
-| daemonset.priorityClassName        | The priority class name for the daemonset pods                                                                       | `""`                               |
-| daemonset.containerSecurityContext | The security context of the containers within the pods of the daemonset                                              | `{}`                               |
-| daemonset.containerResources       | The container resources of the containers within the pods of the daemonset                                           | `{}`                               |
-| daemonset.containerImagePullPolicy | The container image pull policy the pods of the daemonset                                                            | `IfNotPresent`                     |
-| daemonset.tolerations              | The tolerations of the daemonset                                                                                     | See Default tolerations below      |
-| daemonset.dnsConfig                | Specifies the DNS parameters of the pods in the daemonset                                                            | `{}`                               |
-| daemonset.volumeMounts             | Additional volumeMounts to be added to the pods of the daemonset                                                     | `[]`                               |
-| daemonset.volumes                  | Additional volumes to be added to the daemonset                                                                      | `[]`                               |
-| serviceMonitor.enabled             | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | `false`                            |
-| serviceMonitor.labels              | Additional labels to be added to the ServiceMonitor                                                                  | `{}`                               |
-| serviceMonitor.relabelings         | Additional relabelings to be added to the endpoint of the ServiceMonitor                                             | `[]`                               |
-| serviceAccount.name                | The name of the service account which is used                                                                        | `Release.Name`                     |
-| service.name                       | The name of service which exposes the kubenurse application                                                          | `8080-8080`                        |
-| service.port                       | The port number of the service                                                                                       | `8080`                             |
-| service.labels                     | Additional labels to be added to the Service                                                                         |                                    |
-| ingress.enabled                    | Enable/ Disable the ingress                                                                                          | `true`                             |
-| ingress.className                  | The classname of the ingress controller (e.g. the nginx ingress controller)                                          | `nginx`                            |
-| ingress.url                        | The url of the ingress; e.g. kubenurse.westeurope.cloudapp.example.com                                               | `dummy-kubenurse.example.com`      |
-| insecure                           | Set `KUBENURSE_INSECURE` environment variable                                                                        | `true`                             |
-| allow_unschedulable                | Sets `KUBENURSE_ALLOW_UNSCHEDULABLE` environment variable                                                            | `false`                            |
-| neighbour_filter                   | Sets `KUBENURSE_NEIGHBOUR_FILTER` environment variable                                                               | `app.kubernetes.io/name=kubenurse` |
-| neighbour_limit                    | Sets `KUBENURSE_NEIGHBOUR_LIMIT` environment variable                                                                | `10`                               |
-| histogram_buckets                  | Sets `KUBENURSE_HISTOGRAM_BUCKETS` environment variable                                                              |                                    |
-| extra_ca                           | Sets `KUBENURSE_EXTRA_CA` environment variable                                                                       |                                    |
-| extra_checks                       | Sets `KUBENURSE_EXTRA_CHECKS` environment variable                                                                   |                                    |
-| kubernetes_service_dns             | Sets `KUBERNETES_SERVICE_DNS` environment variable                                                                   |                                    |
-| check_api_server_direct            | Sets `KUBENURSE_CHECK_API_SERVER_DIRECT` environment variable                                                        | `true`                             |
-| check_api_server_dns               | Sets `KUBENURSE_CHECK_API_SERVER_DNS` environment variable                                                           | `true`                             |
-| check_me_ingress                   | Sets `KUBENURSE_CHECK_ME_INGRESS` environment variable                                                               | `true`                             |
-| check_me_service                   | Sets `KUBENURSE_CHECK_ME_SERVICE` environment variable                                                               | `true`                             |
-| check_neighbourhood                | Sets `KUBENURSE_CHECK_NEIGHBOURHOOD` environment variable                                                            | `true`                             |
-| check_interval                     | Sets `KUBENURSE_CHECK_INTERVAL` environment variable                                                                 | `5s`                               |
-| reuse_connections                  | Sets `KUBENURSE_REUSE_CONNECTIONS` environment variable                                                              | `false`                            |
-| use_tls                            | Sets `KUBENURSE_USE_TLS` environment variable                                                                        | `false`                            |
-| cert_file                          | Sets `KUBENURSE_CERT_FILE` environment variable                                                                      |                                    |
-| cert_key                           | Sets `KUBENURSE_CERT_KEY` environment variable                                                                       |                                    |
+| Setting                                | Description                                                                                                          | Default                            |
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| daemonset.image.repository             | The repository name                                                                                                  | `postfinance/kubenurse`            |
+| daemonset.image.tag                    | The tag/ version of the image                                                                                        | `v1.4.0`                           |
+| daemonset.podLabels                    | Additional labels to be added to the pods of the daemonset                                                           | `[]`                               |
+| daemonset.podAnnotations               | Additional annotations to be added to the pods of the daemonset                                                      | `[]`                               |
+| daemonset.podSecurityContext           | The security context of the daemonset                                                                                | `{}`                               |
+| daemonset.priorityClassName            | The priority class name for the daemonset pods                                                                       | `""`                               |
+| daemonset.containerSecurityContext     | The security context of the containers within the pods of the daemonset                                              | `{}`                               |
+| daemonset.containerResources           | The container resources of the containers within the pods of the daemonset                                           | `{}`                               |
+| daemonset.containerImagePullPolicy     | The container image pull policy the pods of the daemonset                                                            | `IfNotPresent`                     |
+| daemonset.tolerations                  | The tolerations of the daemonset                                                                                     | See Default tolerations below      |
+| daemonset.dnsConfig                    | Specifies the DNS parameters of the pods in the daemonset                                                            | `{}`                               |
+| daemonset.volumeMounts                 | Additional volumeMounts to be added to the pods of the daemonset                                                     | `[]`                               |
+| daemonset.volumes                      | Additional volumes to be added to the daemonset                                                                      | `[]`                               |
+| daemonset.rollingUpdate.maxUnavailable | The maximum number of DaemonSet pods that can be unavailable during the update                                       | `34%`                              |
+| daemonset.rollingUpdate.maxSurge       | The maximum number of nodes with an existing available DaemonSet pod that can have an updated pod during an update   |                                    |
+| serviceMonitor.enabled                 | Adds a ServiceMonitor for use with [Prometheus-operator](https://github.com/prometheus-operator/prometheus-operator) | `false`                            |
+| serviceMonitor.labels                  | Additional labels to be added to the ServiceMonitor                                                                  | `{}`                               |
+| serviceMonitor.relabelings             | Additional relabelings to be added to the endpoint of the ServiceMonitor                                             | `[]`                               |
+| serviceAccount.name                    | The name of the service account which is used                                                                        | `Release.Name`                     |
+| service.name                           | The name of service which exposes the kubenurse application                                                          | `8080-8080`                        |
+| service.port                           | The port number of the service                                                                                       | `8080`                             |
+| service.labels                         | Additional labels to be added to the Service                                                                         |                                    |
+| ingress.enabled                        | Enable/ Disable the ingress                                                                                          | `true`                             |
+| ingress.className                      | The classname of the ingress controller (e.g. the nginx ingress controller)                                          | `nginx`                            |
+| ingress.url                            | The url of the ingress; e.g. kubenurse.westeurope.cloudapp.example.com                                               | `dummy-kubenurse.example.com`      |
+| insecure                               | Set `KUBENURSE_INSECURE` environment variable                                                                        | `true`                             |
+| allow_unschedulable                    | Sets `KUBENURSE_ALLOW_UNSCHEDULABLE` environment variable                                                            | `false`                            |
+| neighbour_filter                       | Sets `KUBENURSE_NEIGHBOUR_FILTER` environment variable                                                               | `app.kubernetes.io/name=kubenurse` |
+| neighbour_limit                        | Sets `KUBENURSE_NEIGHBOUR_LIMIT` environment variable                                                                | `10`                               |
+| histogram_buckets                      | Sets `KUBENURSE_HISTOGRAM_BUCKETS` environment variable                                                              |                                    |
+| extra_ca                               | Sets `KUBENURSE_EXTRA_CA` environment variable                                                                       |                                    |
+| extra_checks                           | Sets `KUBENURSE_EXTRA_CHECKS` environment variable                                                                   |                                    |
+| kubernetes_service_dns                 | Sets `KUBERNETES_SERVICE_DNS` environment variable                                                                   |                                    |
+| check_api_server_direct                | Sets `KUBENURSE_CHECK_API_SERVER_DIRECT` environment variable                                                        | `true`                             |
+| check_api_server_dns                   | Sets `KUBENURSE_CHECK_API_SERVER_DNS` environment variable                                                           | `true`                             |
+| check_me_ingress                       | Sets `KUBENURSE_CHECK_ME_INGRESS` environment variable                                                               | `true`                             |
+| check_me_service                       | Sets `KUBENURSE_CHECK_ME_SERVICE` environment variable                                                               | `true`                             |
+| check_neighbourhood                    | Sets `KUBENURSE_CHECK_NEIGHBOURHOOD` environment variable                                                            | `true`                             |
+| check_interval                         | Sets `KUBENURSE_CHECK_INTERVAL` environment variable                                                                 | `5s`                               |
+| reuse_connections                      | Sets `KUBENURSE_REUSE_CONNECTIONS` environment variable                                                              | `false`                            |
+| use_tls                                | Sets `KUBENURSE_USE_TLS` environment variable                                                                        | `false`                            |
+| cert_file                              | Sets `KUBENURSE_CERT_FILE` environment variable                                                                      |                                    |
+| cert_key                               | Sets `KUBENURSE_CERT_KEY` environment variable                                                                       |                                    |
 
 </details>
 

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -13,7 +13,9 @@ spec:
       {{- include "kubenurse.selectorLabels" . | nindent 6 }}
   updateStrategy:
     rollingUpdate:
-      maxSurge: 0
+      {{- with .Values.daemonset.rollingUpdate.maxSurge }}
+      maxSurge: {{ . }}
+      {{- end }}
       maxUnavailable: {{ .Values.daemonset.rollingUpdate.maxUnavailable }}
     type: RollingUpdate
   template:

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -22,6 +22,7 @@ daemonset:
   priorityClassName: ""
   rollingUpdate:
     maxUnavailable: 34%
+    # maxSurge:
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
Hi 👋,

This PR fixes the Helm chart so that `spec.updateStrategy.maxSurge` is not set by default.

The reason for this change is that in Kubernetes clusters older than version 1.25, the maxSurge field is unavailable unless the feature gate is enabled[^1]. 

On the other hand, Kubernetes' default behavior is to set maxSurge to 0 if the field is omitted[^2]. Therefore, omitting this field should maintain the current behavior without causing any breaking changes.

[^1]: https://github.com/kubernetes/enhancements/issues/1591
[^2]: https://github.com/kubernetes/enhancements/tree/master/keps/sig-apps/1591-daemonset-surge#implementation-detailsnotesconstraints
