### PR TITLE
feat: introduce VictoriaMetrics/metrics histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | allow_unschedulable                    | Sets `KUBENURSE_ALLOW_UNSCHEDULABLE` environment variable                                                            | `false`                            |
 | neighbour_filter                       | Sets `KUBENURSE_NEIGHBOUR_FILTER` environment variable                                                               | `app.kubernetes.io/name=kubenurse` |
 | neighbour_limit                        | Sets `KUBENURSE_NEIGHBOUR_LIMIT` environment variable                                                                | `10`                               |
+| victoriametrics_histogram              | Sets `KUBENURSE_VICTORIAMETRICS_HISTOGRAM` environment variable                                                      | `false`                              |
 | histogram_buckets                      | Sets `KUBENURSE_HISTOGRAM_BUCKETS` environment variable                                                              |                                    |
 | extra_ca                               | Sets `KUBENURSE_EXTRA_CA` environment variable                                                                       |                                    |
 | extra_checks                           | Sets `KUBENURSE_EXTRA_CHECKS` environment variable                                                                   |                                    |
@@ -163,6 +164,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 - `KUBENURSE_CHECK_NEIGHBOURHOOD`: If this is `"true"`, kubenurse will perform the check [Neighbourhood](#neighbourhood). default is "true"
 - `KUBENURSE_CHECK_INTERVAL`: the frequency to perform kubenurse checks. the string should be formatted for [time.ParseDuration](https://pkg.go.dev/time#ParseDuration). defaults to `5s`
 - `KUBENURSE_REUSE_CONNECTIONS`: whether to reuse connections or not for all checks. default is "false"
+- `KUBENURSE_VICTORIAMETRICS_HISTOGRAM`: if this is "true", kubenurse exposes VictoriaMetrics histograms (i.e. `vmrange` buckets instead of the default Prometheus `le` buckets) 
 - `KUBENURSE_HISTOGRAM_BUCKETS`: optional comma-separated list of float64, used in place of the [default prometheus histogram buckets](https://pkg.go.dev/github.com/prometheus/client_golang@v1.16.0/prometheus#DefBuckets)
 - `KUBENURSE_USE_TLS`: If this is `"true"`, enable TLS endpoint on port 8443
 - `KUBENURSE_CERT_FILE`: Certificate to use with TLS endpoint

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ toolchain go1.24.2
 
 require (
 	github.com/VictoriaMetrics/metrics v0.0.0-00010101000000-000000000000
-	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
@@ -41,6 +40,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
+	github.com/VictoriaMetrics/metrics v0.0.0-00010101000000-000000000000
 	github.com/prometheus/client_golang v1.22.0
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
 	k8s.io/client-go v0.33.1
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/controller-runtime v0.21.0
 )
 
@@ -43,6 +45,8 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/valyala/fastrand v1.1.0 // indirect
+	github.com/valyala/histogram v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
@@ -57,7 +61,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.33.0 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
@@ -65,3 +68,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/VictoriaMetrics/metrics => github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/VictoriaMetrics/metrics v0.0.0-00010101000000-000000000000
+	github.com/VictoriaMetrics/metrics v1.38.0
 	github.com/stretchr/testify v1.10.0
 	k8s.io/api v0.33.1
 	k8s.io/apimachinery v0.33.1
@@ -68,5 +68,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/VictoriaMetrics/metrics => github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c h1:qeSyc+2dGEnj1EFo5N6+Agg/8P3k3MUaAsbDLILdZWc=
+github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -107,6 +109,10 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/valyala/fastrand v1.1.0 h1:f+5HkLW4rsgzdNoleUOB69hyT9IlD2ZQh9GyDMfb5G8=
+github.com/valyala/fastrand v1.1.0/go.mod h1:HWqCzkrkg6QXT8V2EXWvXCoow7vLwOFN002oeRzjapQ=
+github.com/valyala/histogram v1.2.0 h1:wyYGAZZt3CpwUiIb9AU/Zbllg1llXyrtApRS815OLoQ=
+github.com/valyala/histogram v1.2.0/go.mod h1:Hb4kBwb4UxsaNbbbh+RRz8ZR6pdodR57tzWUS3BUzXY=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
+github.com/VictoriaMetrics/metrics v1.38.0 h1:1d0dRgVH8Nnu8dKMfisKefPC3q7gqf3/odyO0quAvyA=
+github.com/VictoriaMetrics/metrics v1.38.0/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c h1:qeSyc+2dGEnj1EFo5N6+Agg/8P3k3MUaAsbDLILdZWc=
-github.com/clementnuss/metrics v1.37.1-0.20250609092909-f96d9d13f07c/go.mod h1:r7hveu6xMdUACXvB8TYdAj8WEsKzWB0EkpJN+RDtOf8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -75,6 +75,8 @@ spec:
         - name: KUBENURSE_HISTOGRAM_BUCKETS
           value: {{ .Values.histogram_buckets | quote }}
           {{- end }}
+        - name: KUBENURSE_VICTORIAMETRICS_HISTOGRAM
+          value: {{ .Values.victoriametrics_histogram | quote }}
         - name: KUBENURSE_CHECK_API_SERVER_DIRECT
           value: {{ .Values.check_api_server_direct | quote }}
         - name: KUBENURSE_CHECK_API_SERVER_DNS

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -52,6 +52,8 @@ neighbour_limit: 10
 # KUBENURSE_HISTOGRAM_BUCKETS
 histogram_buckets: ""
 # histogram_buckets: ".0005,.001,.0025,.005,.01,.025,.05,0.1,0.25,0.5,1" # default prometheus histogram buckets divided by 10
+# KUBENURSE_VICTORIAMETRICS_HISTOGRAM
+victoriametrics_histogram: false
 # KUBENURSE_EXTRA_CA
 extra_ca: ""
 # KUBENURSE_CHECK_API_SERVER_DIRECT

--- a/internal/kubenurse/server.go
+++ b/internal/kubenurse/server.go
@@ -185,7 +185,6 @@ func New(c client.Client) (*Server, error) { //nolint:funlen // TODO: use a flag
 	mux.HandleFunc("/ready", server.readyHandler())
 	mux.HandleFunc("/alive", server.aliveHandler())
 	mux.HandleFunc("/alwayshappy", server.alwaysHappyHandler())
-	// mux.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
 	mux.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
 		metrics.WritePrometheus(w, true)
 	})

--- a/internal/servicecheck/httptrace.go
+++ b/internal/servicecheck/httptrace.go
@@ -37,10 +37,7 @@ func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return rt(r)
 }
 
-// This collects traces and logs errors. As promhttp.InstrumentRoundTripperTrace doesn't process
-// errors, this is custom made and inspired by prometheus/client_golang's promhttp
-//
-//nolint:funlen // needed to pack all histograms and use them directly in the httptrace wrapper
+// withHttptrace collects traces, measures durations and counts requests+errors.
 func withHttptrace(next http.RoundTripper, histogramGetter func(string) Histogram) http.RoundTripper {
 	collectMetric := func(traceEventType string, start time.Time, r *http.Request, err error) {
 		kubenurseTypeLabel := r.Context().Value(kubenurseTypeKey{}).(string)

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,8 +30,10 @@ func New(cl client.Client, allowUnschedulable bool, cacheTTL time.Duration, hist
 	// setup http transport
 	tlsConfig, err := generateTLSConfig(os.Getenv("KUBENURSE_EXTRA_CA"))
 	if err != nil {
-		slog.Error("cannot generate tlsConfig with provided KUBENURSE_EXTRA_CA. Continuing with default tlsConfig",
-			"KUBENURSE_EXTRA_CA", os.Getenv("KUBENURSE_EXTRA_CA"), "err", err)
+		if !testing.Testing() {
+			slog.Error("cannot generate tlsConfig with provided KUBENURSE_EXTRA_CA. Continuing with default tlsConfig",
+				"KUBENURSE_EXTRA_CA", os.Getenv("KUBENURSE_EXTRA_CA"), "err", err)
+		}
 
 		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
 	}

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,9 +26,7 @@ const (
 
 // New configures the checker with a httpClient and a cache timeout for check
 // results. Other parameters of the Checker struct need to be configured separately.
-func New(cl client.Client, promRegistry *prometheus.Registry,
-	allowUnschedulable bool, cacheTTL time.Duration, durationHistogramBuckets []float64,
-) (*Checker, error) {
+func New(cl client.Client, allowUnschedulable bool, cacheTTL time.Duration, durationHistogramBuckets []float64) (*Checker, error) {
 	// setup http transport
 	tlsConfig, err := generateTLSConfig(os.Getenv("KUBENURSE_EXTRA_CA"))
 	if err != nil {
@@ -58,7 +55,7 @@ func New(cl client.Client, promRegistry *prometheus.Registry,
 
 	httpClient := &http.Client{
 		Timeout:   dialTimeout + time.Second,
-		Transport: withHttptrace(promRegistry, transport, durationHistogramBuckets),
+		Transport: withHttptrace(transport, durationHistogramBuckets),
 	}
 
 	return &Checker{

--- a/internal/servicecheck/servicecheck.go
+++ b/internal/servicecheck/servicecheck.go
@@ -17,16 +17,15 @@ import (
 )
 
 const (
-	okStr            = "ok"
-	errStr           = "error"
-	skippedStr       = "skipped"
-	MetricsNamespace = "kubenurse"
-	dialTimeout      = 5 * time.Second
+	okStr       = "ok"
+	errStr      = "error"
+	skippedStr  = "skipped"
+	dialTimeout = 5 * time.Second
 )
 
 // New configures the checker with a httpClient and a cache timeout for check
 // results. Other parameters of the Checker struct need to be configured separately.
-func New(cl client.Client, allowUnschedulable bool, cacheTTL time.Duration, durationHistogramBuckets []float64) (*Checker, error) {
+func New(cl client.Client, allowUnschedulable bool, cacheTTL time.Duration, histogramGetter func(s string) Histogram) (*Checker, error) {
 	// setup http transport
 	tlsConfig, err := generateTLSConfig(os.Getenv("KUBENURSE_EXTRA_CA"))
 	if err != nil {
@@ -55,7 +54,7 @@ func New(cl client.Client, allowUnschedulable bool, cacheTTL time.Duration, dura
 
 	httpClient := &http.Client{
 		Timeout:   dialTimeout + time.Second,
-		Transport: withHttptrace(transport, durationHistogramBuckets),
+		Transport: withHttptrace(transport, histogramGetter),
 	}
 
 	return &Checker{

--- a/internal/servicecheck/servicecheck_test.go
+++ b/internal/servicecheck/servicecheck_test.go
@@ -4,14 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/VictoriaMetrics/metrics"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,8 +38,7 @@ func TestCombined(t *testing.T) {
 	// fake client, with a dummy neighbour pod
 	fakeClient := fake.NewFakeClient(&fakeNeighbourPod)
 
-	promRegistry := prometheus.NewRegistry()
-	checker, err := New(fakeClient, promRegistry, false, 3*time.Second, prometheus.DefBuckets)
+	checker, err := New(fakeClient, false, 3*time.Second, metrics.PrometheusHistogramDefaultBuckets)
 	checker.SkipCheckAPIServerDNS = true
 	checker.SkipCheckAPIServerDirect = true
 
@@ -64,10 +59,5 @@ func TestCombined(t *testing.T) {
 
 	var bb bytes.Buffer
 	metrics.WritePrometheus(&bb, false)
-
 	fmt.Println(bb.String())
-
-	rw := httptest.NewRecorder()
-	promhttp.HandlerFor(promRegistry,promhttp.HandlerOpts{}).ServeHTTP(rw, &http.Request{})
-	fmt.Println(rw.Body.String())
 }

--- a/internal/servicecheck/servicecheck_test.go
+++ b/internal/servicecheck/servicecheck_test.go
@@ -69,8 +69,4 @@ func TestCombined(t *testing.T) {
 		r.Equal(okStr, checker.LastCheckResult["check_ok"])
 		r.Equal("404 Not Found", checker.LastCheckResult["check_not_found"])
 	})
-
-	// var bb bytes.Buffer
-	// metrics.WritePrometheus(&bb, false)
-	// fmt.Println(bb.String())
 }

--- a/internal/servicecheck/transport.go
+++ b/internal/servicecheck/transport.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"testing"
 )
 
 const (
@@ -24,7 +25,9 @@ func (c *Checker) doRequest(ctx context.Context, url string, addOriginHeader boo
 	token, err := os.ReadFile(K8sTokenFile)
 	if err != nil {
 		slog.Error("error in doRequest while reading k8sTokenFile", "err", err)
-		return errStr
+		if !testing.Testing() {
+			return errStr
+		}
 	}
 
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)

--- a/internal/servicecheck/transport.go
+++ b/internal/servicecheck/transport.go
@@ -23,11 +23,9 @@ const (
 func (c *Checker) doRequest(ctx context.Context, url string, addOriginHeader bool) string {
 	// Read Bearer Token file from ServiceAccount
 	token, err := os.ReadFile(K8sTokenFile)
-	if err != nil {
+	if !testing.Testing() && err != nil {
 		slog.Error("error in doRequest while reading k8sTokenFile", "err", err)
-		if !testing.Testing() {
-			return errStr
-		}
+		return errStr
 	}
 
 	req, _ := http.NewRequestWithContext(ctx, "GET", url, http.NoBody)

--- a/internal/util/metrics.go
+++ b/internal/util/metrics.go
@@ -1,21 +1,24 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const MetricsNamespace = "kubenurse"
 
 func GenMetricsName(name string, kvs ...string) string {
 	n := len(kvs)
-	labels := ""
+	labels := make([]string, n/2)
+
 	if n > 0 {
 		if n%2 != 0 {
 			panic("odd number or label tags, cannot construct the metric name")
 		}
 		for i := 0; i < n; i += 2 {
-			labels += fmt.Sprintf("%s=%q,", kvs[i], kvs[i+1])
+			labels[i/2] = fmt.Sprintf("%s=%q", kvs[i], kvs[i+1])
 		}
-		labels = labels[:len(labels)-1]
 	}
 
-	return fmt.Sprintf("%s_%s{%s}", MetricsNamespace, name, labels)
+	return fmt.Sprintf("%s_%s{%s}", MetricsNamespace, name, strings.Join(labels, ","))
 }

--- a/internal/util/metrics.go
+++ b/internal/util/metrics.go
@@ -1,0 +1,21 @@
+package util
+
+import "fmt"
+
+const MetricsNamespace = "kubenurse"
+
+func GenMetricsName(name string, kvs ...string) string {
+	n := len(kvs)
+	labels := ""
+	if n > 0 {
+		if n%2 != 0 {
+			panic("odd number or label tags, cannot construct the metric name")
+		}
+		for i := 0; i < n; i += 2 {
+			labels += fmt.Sprintf("%s=%q,", kvs[i], kvs[i+1])
+		}
+		labels = labels[:len(labels)-1]
+	}
+
+	return fmt.Sprintf("%s_%s{%s}", MetricsNamespace, name, labels)
+}

--- a/internal/util/metrics_test.go
+++ b/internal/util/metrics_test.go
@@ -1,0 +1,54 @@
+package util_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/postfinance/kubenurse/internal/util"
+)
+
+func BenchmarkGenMetrics(b *testing.B) {
+	labels := make([]string, 0, 10)
+	for range cap(labels) {
+		labels = append(labels, rand.Text())
+	}
+
+	for b.Loop() {
+		util.GenMetricsName("test", labels...)
+	}
+}
+
+// BenchmarkOptimizedGenMetrics spun out of a discussion on Join() vs
+// strings.Builder comparison. the strings.Join() was used in the end for its
+// readibility and the <1% overhead.
+func BenchmarkOptimizedGenMetrics(b *testing.B) {
+	labels := make([]string, 0, 10)
+	for range cap(labels) {
+		labels = append(labels, rand.Text())
+	}
+
+	optimizedGenMetrics := func(name string, kvs ...string) string {
+		n := len(kvs)
+		var labels string
+		b := strings.Builder{}
+		b.Grow(30 * n) // let's assume each label/value is 30
+
+		if n > 0 {
+			if n%2 != 0 {
+				panic("odd number or label tags, cannot construct the metric name")
+			}
+			for i := 0; i < n; i += 2 {
+				b.WriteString(fmt.Sprintf("%s=%q,", kvs[i], kvs[i+1]))
+			}
+			labels = b.String()
+			labels = labels[:len(labels)-1]
+		}
+
+		return fmt.Sprintf("%s_%s{%s}", util.MetricsNamespace, name, labels)
+	}
+	for b.Loop() {
+		optimizedGenMetrics("test", labels...)
+	}
+}


### PR DESCRIPTION
makes it possible to choose between `PrometheusHistogram` (introduced [here](https://github.com/VictoriaMetrics/metrics/pull/93)) or VictoriaMetrics histograms.

the former keep the actual behaviour, with predefined histogram buckets, while the latter introduce VictoriaMetrics `vmrange` buckets, as introduced by @valyala [here](https://valyala.medium.com/improving-histogram-usability-for-prometheus-and-grafana-bc7e5df0e350).

here's a comparison between the 2 flavours. I let you decide which one is more informative 😉 

<img width="1764" alt="image" src="https://github.com/user-attachments/assets/ab833f59-08e6-4c78-a2c9-a1cb1af1eb4b" />

<img width="1755" alt="image" src="https://github.com/user-attachments/assets/ead5efc5-86d9-4786-b9c1-770b4f4439e0" />
