### PR TITLE
feat(helm): add imagePullSecrets support

### DIFF
--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
       {{ toYaml .Values.daemonset.podSecurityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kubenurse.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "kubenurse.name" . | quote }}
         securityContext:

--- a/helm/kubenurse/templates/serviceaccount.yaml
+++ b/helm/kubenurse/templates/serviceaccount.yaml
@@ -6,7 +6,3 @@ metadata:
   labels:
     {{- include "kubenurse.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
-{{- with .Values.serviceAccount.imagePullSecrets }}
-imagePullSecrets:
-  {{- toYaml . | nindent 2 }}
-{{- end }}

--- a/helm/kubenurse/templates/serviceaccount.yaml
+++ b/helm/kubenurse/templates/serviceaccount.yaml
@@ -6,3 +6,7 @@ metadata:
   labels:
     {{- include "kubenurse.labels" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -88,15 +88,16 @@ cert_key: ""
 nameOverride: ""
 fullnameOverride: ""
 
+# List of image pull secrets to attach to all pods
+imagePullSecrets: []
+# - name: my-registry-secret
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  # List of image pull secrets to attach to the service account
-  imagePullSecrets: []
-  # - name: my-registry-secret
 
 service:
   name: 8080-8080

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -94,6 +94,9 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  # List of image pull secrets to attach to the service account
+  imagePullSecrets: []
+  # - name: my-registry-secret
 
 service:
   name: 8080-8080


### PR DESCRIPTION
## Summary

Adds `imagePullSecrets` to the DaemonSet pod spec, allowing kubenurse to pull images from private registries.

## Changes

- `values.yaml`: added top-level `imagePullSecrets: []` with example comment
- `templates/daemonset.yaml`: renders `imagePullSecrets` on the pod spec when non-empty

## Usage

```
imagePullSecrets:
  - name: my-registry-secret
```

When not set (default `[]`), the field is omitted entirely — no behaviour change for existing users.

## Motivation

Environments that mirror images into private registries (e.g. Harbor, ECR, GCR) need to attach pull credentials to pods. This is the standard Helm chart pattern used by cert-manager, ingress-nginx, and others.
