### PR TITLE
add feature to expose metric metadata at /metrics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 | allow_unschedulable                    | Sets `KUBENURSE_ALLOW_UNSCHEDULABLE` environment variable                                                            | `false`                            |
 | neighbour_filter                       | Sets `KUBENURSE_NEIGHBOUR_FILTER` environment variable                                                               | `app.kubernetes.io/name=kubenurse` |
 | neighbour_limit                        | Sets `KUBENURSE_NEIGHBOUR_LIMIT` environment variable                                                                | `10`                               |
-| victoriametrics_histogram              | Sets `KUBENURSE_VICTORIAMETRICS_HISTOGRAM` environment variable                                                      | `false`                              |
+| victoriametrics_histogram              | Sets `KUBENURSE_VICTORIAMETRICS_HISTOGRAM` environment variable                                                      | `false`                            |
 | histogram_buckets                      | Sets `KUBENURSE_HISTOGRAM_BUCKETS` environment variable                                                              |                                    |
+| expose_metadata                        | Sets `KUBENURSE_EXPOSE_METADATA` environment variable                                                                | `false`                            |
 | extra_ca                               | Sets `KUBENURSE_EXTRA_CA` environment variable                                                                       |                                    |
 | extra_checks                           | Sets `KUBENURSE_EXTRA_CHECKS` environment variable                                                                   |                                    |
 | kubernetes_service_dns                 | Sets `KUBERNETES_SERVICE_DNS` environment variable                                                                   |                                    |
@@ -166,6 +167,7 @@ The following command can be used to install kubenurse with Helm: `helm upgrade 
 - `KUBENURSE_REUSE_CONNECTIONS`: whether to reuse connections or not for all checks. default is "false"
 - `KUBENURSE_VICTORIAMETRICS_HISTOGRAM`: if this is "true", kubenurse exposes VictoriaMetrics histograms (i.e. `vmrange` buckets instead of the default Prometheus `le` buckets) 
 - `KUBENURSE_HISTOGRAM_BUCKETS`: optional comma-separated list of float64, used in place of the [default prometheus histogram buckets](https://pkg.go.dev/github.com/prometheus/client_golang@v1.16.0/prometheus#DefBuckets)
+- `KUBENURSE_EXPOSE_METADATA`: If this is `"true"`, expose TYPE and HELP metadata at the /metrics page
 - `KUBENURSE_USE_TLS`: If this is `"true"`, enable TLS endpoint on port 8443
 - `KUBENURSE_CERT_FILE`: Certificate to use with TLS endpoint
 - `KUBENURSE_CERT_KEY`: Key to use with TLS endpoint

--- a/helm/kubenurse/templates/daemonset.yaml
+++ b/helm/kubenurse/templates/daemonset.yaml
@@ -79,6 +79,8 @@ spec:
         - name: KUBENURSE_HISTOGRAM_BUCKETS
           value: {{ .Values.histogram_buckets | quote }}
           {{- end }}
+        - name: KUBENURSE_EXPOSE_METADATA
+          value: {{ .Values.expose_metadata | quote }}
         - name: KUBENURSE_VICTORIAMETRICS_HISTOGRAM
           value: {{ .Values.victoriametrics_histogram | quote }}
         - name: KUBENURSE_CHECK_API_SERVER_DIRECT

--- a/helm/kubenurse/values.yaml
+++ b/helm/kubenurse/values.yaml
@@ -55,6 +55,8 @@ neighbour_filter: app.kubernetes.io/name=kubenurse
 neighbour_limit: 10
 # KUBENURSE_HISTOGRAM_BUCKETS
 histogram_buckets: ""
+# KUBENURSE_EXPOSE_METADATA
+expose_metadata: false
 # histogram_buckets: ".0005,.001,.0025,.005,.01,.025,.05,0.1,0.25,0.5,1" # default prometheus histogram buckets divided by 10
 # KUBENURSE_VICTORIAMETRICS_HISTOGRAM
 victoriametrics_histogram: false

--- a/internal/kubenurse/server.go
+++ b/internal/kubenurse/server.go
@@ -55,6 +55,7 @@ type Server struct {
 // * KUBENURSE_CHECK_ME_SERVICE
 // * KUBENURSE_CHECK_NEIGHBOURHOOD
 // * KUBENURSE_CHECK_INTERVAL
+// * KUBENURSE_EXPOSE_METADATA
 func New(c client.Client) (*Server, error) { //nolint:funlen // TODO: use a flag parsing library (e.g. ff) to reduce complexity
 	mux := http.NewServeMux()
 
@@ -93,6 +94,10 @@ func New(c client.Client) (*Server, error) { //nolint:funlen // TODO: use a flag
 
 	server.ready.Store(true)
 	server.neighboursTTLCache.Init(60 * time.Second)
+
+	if os.Getenv("KUBENURSE_EXPOSE_METADATA") == "true" {
+		metrics.ExposeMetadata(true)
+	}
 
 	var histogramBuckets []float64
 


### PR DESCRIPTION
## Summary

Adds support to expose TYPE and HELP metadata at the /metrics page - https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5683

## Changes

- `values.yaml`: added expose_metadata: false
- `templates/daemonset.yaml`: add environmend variable to expose metrics at /metrics page
- `internal/kubenurse/server.go`: add feature to expose metadata at /metrics page

## Usage

```
expose_metadata: true
```

When not set (default `false`) - no behaviour change for existing users.

## Motivation

Some scrapers requires metadata to be available when calling the /metrics endpoint (eq. datadog-agent)
